### PR TITLE
Update homebrew cask install due to 2.7 deprecation of cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [Download the latest release][download-latest] or install via Homebrew:
 
 ```sh
+# Latest homebrew:
+brew install --cask odlp/bluesnooze/bluesnooze
+
+# Homebrew 2.5 or below
 brew cask install odlp/bluesnooze/bluesnooze
 ```
 


### PR DESCRIPTION
For more info: https://github.com/Homebrew/discussions/discussions/340

Running the original readme command on the latest Homebrew is giving an error. I left both options in the readme since a lot of people don't update homebrew often.

PS: thanks for the app!