### PR TITLE
Feature Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ You might also want to check-out Whisper –  [the volume limiter for MacOS](htt
 
 [download-latest]: https://github.com/odlp/bluesnooze/releases/latest
 
+
+
 ## Enjoying Bluesnooze?
 
 Perhaps you could [buy me a coffee](https://www.buymeacoffee.com/odlp) to say thanks :coffee:


### PR DESCRIPTION
Hey, as Issues are not allowed (is that on purpose?), I wanted to propose the following feature, but maybe it is out of scope:

# Problem
I have two headphones:
One of them can only connect to one device at a time. That one I would like to disconnect on snooze.
The other one can connect to two devices at a time. That one I would like not to disconnect on snooze.

# Possible Solution
I am aware that blueznooze currently totally disables bluetooth. This feature would require to selectively disconnect devices

# Alternatives
It might be possible to achieve this with another tool, for example http://www.hammerspoon.org/