### PR TITLE
remembering if bluetooth was on/off prior to sleep/shutdown

### DIFF
--- a/Bluesnooze/AppDelegate.swift
+++ b/Bluesnooze/AppDelegate.swift
@@ -17,12 +17,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var launchAtLoginMenuItem: NSMenuItem!
 
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    private var prevState: Int32 = IOBluetoothPreferenceGetControllerPowerState()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         initStatusItem()
         setLaunchAtLoginState()
         setupNotificationHandlers()
-        setBluetooth(powerOn: true)
     }
 
     // MARK: Click handlers
@@ -54,11 +54,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func onPowerDown(note: NSNotification) {
+        prevState = IOBluetoothPreferenceGetControllerPowerState()
         setBluetooth(powerOn: false)
     }
 
     @objc func onPowerUp(note: NSNotification) {
-        setBluetooth(powerOn: true)
+        if prevState != 0 {
+            setBluetooth(powerOn: true)
+        }
     }
 
     private func setBluetooth(powerOn: Bool) {

--- a/Bluesnooze/Bluesnooze-Bridging-Header.h
+++ b/Bluesnooze/Bluesnooze-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 void IOBluetoothPreferenceSetControllerPowerState(int);
+int IOBluetoothPreferenceGetControllerPowerState();


### PR DESCRIPTION
I love this app. However, the fact that it turns the Bluetooth on every time I wake it up from sleep even though it was off prior to sleep, is very annoying. Also, I do not think the app should turn on Bluetooth when it is launched, but only on the events it is supposed to.

Since there is no issues tab here (no clue why) I thought I could implement the feature and do a pull request. Feel free to change my implementation, it is just an idea.