### PR TITLE
Configurable power up actions

### DIFF
--- a/Bluesnooze/AppDelegate.swift
+++ b/Bluesnooze/AppDelegate.swift
@@ -17,12 +17,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var launchAtLoginMenuItem: NSMenuItem!
 
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    private var prevState: Int32 = IOBluetoothPreferenceGetControllerPowerState()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         initStatusItem()
         setLaunchAtLoginState()
         setupNotificationHandlers()
-        setBluetooth(powerOn: true)
     }
 
     // MARK: Click handlers
@@ -54,11 +54,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func onPowerDown(note: NSNotification) {
+        prevState = IOBluetoothPreferenceGetControllerPowerState()
         setBluetooth(powerOn: false)
     }
 
     @objc func onPowerUp(note: NSNotification) {
-        setBluetooth(powerOn: true)
+        if prevState != 0 {
+            setBluetooth(powerOn: true)
+        }
     }
 
     private func setBluetooth(powerOn: Bool) {

--- a/Bluesnooze/Base.lproj/MainMenu.xib
+++ b/Bluesnooze/Base.lproj/MainMenu.xib
@@ -14,6 +14,9 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Bluesnooze" customModuleProvider="target">
             <connections>
+                <outlet property="onPowerUpActionRemember" destination="mBz-mB-SAw" id="dpV-qb-pVO"/>
+                <outlet property="onPowerUpActionAlways" destination="k9U-YJ-Qra" id="iPK-GH-kd9"/>
+                <outlet property="onPowerUpActionNever" destination="wwz-8o-dOW" id="kwY-c8-qPz"/>
                 <outlet property="launchAtLoginMenuItem" destination="I9E-pI-lLm" id="DFX-bS-N3m"/>
                 <outlet property="statusMenu" destination="AEO-aA-1fp" id="ueI-UR-7ba"/>
             </connections>
@@ -21,7 +24,32 @@
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu id="AEO-aA-1fp">
             <items>
-                <menuItem title="Launch at login" id="I9E-pI-lLm" userLabel="Launch At Login Menu Item">
+                <menuItem title="Start Bluetooth on wake" id="MrC-mk-c9a" userLabel="Start Bluetooth on wake">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Start Bluetooth on wake" id="6db-i4-kn8">
+                        <items>
+                            <menuItem title="Remember previous state" id="mBz-mB-SAw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="onPowerUpActionRememberClicked:" target="Voe-Tx-rLC" id="eue-OR-a53"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Always" id="k9U-YJ-Qra">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="onPowerUpActionAlwaysClicked:" target="Voe-Tx-rLC" id="CZN-qU-PVs"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Never" id="wwz-8o-dOW">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="onPowerUpActionNeverClicked:" target="Voe-Tx-rLC" id="Gg5-n6-rUW"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Launch at login" id="I9E-pI-lLm">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="launchAtLoginClicked:" target="Voe-Tx-rLC" id="ooK-DW-6Kn"/>

--- a/Bluesnooze/Base.lproj/MainMenu.xib
+++ b/Bluesnooze/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -33,14 +33,14 @@
                         <action selector="hideIconClicked:" target="Voe-Tx-rLC" id="rZI-1a-Hhe"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Quit" id="0IH-xa-Tvk">
-                    <modifierMask key="keyEquivalentModifierMask"/>
+                <menuItem isSeparatorItem="YES" id="lFK-Uh-kIG"/>
+                <menuItem title="Quit" keyEquivalent="q" id="0IH-xa-Tvk">
                     <connections>
                         <action selector="quitClicked:" target="Voe-Tx-rLC" id="nzv-74-hhE"/>
                     </connections>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="-64.5" y="68"/>
+            <point key="canvasLocation" x="-64.5" y="56.5"/>
         </menu>
     </objects>
 </document>

--- a/Bluesnooze/Bluesnooze-Bridging-Header.h
+++ b/Bluesnooze/Bluesnooze-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 void IOBluetoothPreferenceSetControllerPowerState(int);
+int IOBluetoothPreferenceGetControllerPowerState();


### PR DESCRIPTION
Hello,

I made an attempt to compile https://github.com/odlp/bluesnooze/pull/14 and then I wanted to try to improve it a little bit. In my opinion almost everyone would want it to always remember, but on the off chance that someone wants it to be more customizable, here's the option. I'm not very good at Swift so I'm sure there are better ways of doing what I did. :)

Changes:
- Add option to configure what action should be done when waking up the computer. Defaults to <kbd>Remember previous state</kbd>.
  <img width="485" alt="Screen Shot" src="https://user-images.githubusercontent.com/1991151/184558109-a6cc4edc-e334-494d-8c52-d5ecca6c8890.png">
- Add <kbd>Cmd</kbd> + <kbd>Q</kbd> shortcut to Quit menu item.

Cheers!

---

Since this application doesn't seem to be maintained, I also wanted to make a build available for download. You can download it here: https://github.com/stefansundin/bluesnooze/releases/tag/v1.2

You have to bypass a Gatekeeper warning, but there are instructions (with screenshots) on the download page that shows you how to do it.
