### PR TITLE
Improve docs for hide/show menu bar icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ experiment as you like ✌️
 In your terminal run the following command:
 
 ```sh
-defaults write com.oliverpeate.Bluesnooze hideIcon -bool true && killall Bluesnooze
+killall Bluesnooze && defaults write com.oliverpeate.Bluesnooze hideIcon -bool true
 ```
 
 When you next relaunch the application there should be no icon in the menu bar.
@@ -64,7 +64,7 @@ When you next relaunch the application there should be no icon in the menu bar.
 In your terminal run the following command:
 
 ```sh
-defaults delete com.oliverpeate.Bluesnooze hideIcon && killall Bluesnooze
+killall Bluesnooze && defaults delete com.oliverpeate.Bluesnooze hideIcon
 ```
 
 When you next relaunch the application it should appear in the menu bar.


### PR DESCRIPTION
Empirically, at least on my machine (weasel words I know, sorry), I couldn't seem to make the `defaults write` "stick" if I performed it while Bluesnooze was still running. I was able to hide the menu bar icon by writing defaults when Bluesnooze was not already running, and similarly to get it showing again.

---

Related: https://github.com/odlp/bluesnooze/issues/27

I'm not sure if something else in my environment was causing the issue, but these tweaked instructions might be more reliable? Up to the maintainer, I might have missed something!